### PR TITLE
Update destination directory in OCS GH pages.

### DIFF
--- a/.github/workflows/docs-gh-pages.yml
+++ b/.github/workflows/docs-gh-pages.yml
@@ -29,7 +29,7 @@ jobs:
         external_repository: observatorycontrolsystem/observatorycontrolsystem.github.io
         publish_branch: main
         publish_dir: docs
-        destination_dir: docs
+        destination_dir: assets/html
         enable_jekyll: true
         keep_files: true
         exclude_assets: '.github,openapi,.redocly.yaml,LICENSE,README.md,make.sh'


### PR DESCRIPTION
We no longer want to push the pre-built HTML docs to the docs/ directory, but rather the assets/html/ directory in the OCS GitHub pages project.

[Docs here](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-deploy-to-subdirectory-destination_dir)